### PR TITLE
Clean up some clippy warnings, and allow parsing of non-URL inputs

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -15,4 +15,6 @@ fn main() {
     let ext = TldExtractor::new(option());
     let tld = ext.extract("http://forums.news.cnn.com/").unwrap();
     println!("TLD for 'http://forums.news.cnn.com/' is '{:?}'", tld);
+    let tld = ext.extract("forums.news.cnn.com").unwrap();
+    println!("TLD for 'forums.news.cnn.com' is '{:?}'", tld);
 }


### PR DESCRIPTION
Hello!

This PR is a fairly small PR which checks for the presence of `:` in the input prior to attempting to parse as a URL.
This allows inputs such as bare subdomains to be parsed. I've also updated to example to demonstrate this.

Whilst making these changes I also cleaned up several warnings generated by clippy. My testing shows everything is working as expected, but please be mindful of those changes when reviewing, as my test cases were not exactly complex.