### PR TITLE
Exception wildcard improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,24 +181,28 @@ impl TldExtractor {
             let exception_piece = "!".to_string() + &piece;
             let wildcard_piece = "*.".to_string() + &segs[i + 1..].join(".");
 
-            if self.tld_cache.get(&exception_piece).is_some() {
-                continue;
-            }
-
             if self
                 .tld_cache
                 .get(&piece)
                 .or_else(|| self.tld_cache.get(&wildcard_piece))
                 .is_some()
             {
-                suffix = Some(piece);
-                if i != 0 {
-                    domain = Some(segs[i - 1].to_string());
-                    subdomain = if segs[0..i - 1].is_empty() {
-                        None
+                let subdomain_idx = if self.tld_cache.get(&exception_piece).is_some() {
+                    suffix = Some(wildcard_piece[2..].to_string());
+                    domain = Some(segs[i].to_string());
+                    i
+                } else {
+                    suffix = Some(piece);
+                    if i != 0 {
+                        domain = Some(segs[i - 1].to_string());
+                        i - 1
                     } else {
-                        Some(segs[0..i - 1].join("."))
-                    };
+                        0
+                    }
+                };
+
+                if subdomain_idx != 0 && !segs[0..subdomain_idx].is_empty() {
+                    subdomain = Some(segs[0..subdomain_idx].join("."));
                 }
 
                 break;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -349,6 +349,59 @@ fn whole_url_is_a_suffix() {
     );
 }
 
+
+#[test]
+fn wildcards() {
+    let ext = TldOption::default().build();
+    // kawasaki.jp
+    assert_eq!(
+        ext.extract("kawasaki.jp").unwrap(),
+        TldResult::new(None, "kawasaki", "jp")
+    );
+    assert_eq!(
+        ext.extract("city.kawasaki.jp").unwrap(),
+        TldResult::new(None, "city", "kawasaki.jp")
+    );
+    assert_eq!(
+        ext.extract("sub-domain.city.kawasaki.jp").unwrap(),
+        TldResult::new("sub-domain", "city", "kawasaki.jp")
+    );
+    assert_eq!(
+        ext.extract("random.kawasaki.jp").unwrap(),
+        TldResult::new(None, None, "random.kawasaki.jp")
+    );
+    assert_eq!(
+        ext.extract("domain.random.kawasaki.jp").unwrap(),
+        TldResult::new(None, "domain", "random.kawasaki.jp")
+    );
+    assert_eq!(
+        ext.extract("sub-domain.domain.random.kawasaki.jp").unwrap(),
+        TldResult::new("sub-domain", "domain", "random.kawasaki.jp")
+    );
+
+    // ck
+    assert_eq!(
+        ext.extract("www.ck").unwrap(),
+        TldResult::new(None, "www", "ck")
+    );
+    assert_eq!(
+        ext.extract("sub-domain.www.ck").unwrap(),
+        TldResult::new("sub-domain", "www", "ck")
+    );
+    assert_eq!(
+        ext.extract("random.ck").unwrap(),
+        TldResult::new(None, None, "random.ck")
+    );
+    assert_eq!(
+        ext.extract("domain.random.ck").unwrap(),
+        TldResult::new(None, "domain", "random.ck")
+    );
+    assert_eq!(
+        ext.extract("sub-domain.domain.random.ck").unwrap(),
+        TldResult::new("sub-domain", "domain", "random.ck")
+    );
+}
+
 #[test]
 fn public_suffix_list_custom_local_file() {
     let file_path: std::path::PathBuf = [


### PR DESCRIPTION
While writing some tests, I noticed that I was having issues when the string being processed falls into one of the exception wildcard labels in the Public Suffix List, after debugging for a while I discovered that basically the exception wildcard is skipped in the `extract_triple` function, this PR fixes that by adding some handling logic.

Example
---

Code:

```rust
let ext = TldOption::default().build();
println!("{:?}", ext.extract("city.kawasaki.jp").unwrap());
println!("{:?}", ext.extract("www.city.kawasaki.jp").unwrap());
```

Output before the change

```rust
TldResult { domain: Some("kawasaki"), subdomain: Some("city"), suffix: Some("jp") }
TldResult { domain: Some("kawasaki"), subdomain: Some("www.city"), suffix: Some("jp") }
```

Output after the change

```rust
TldResult { domain: Some("city"), subdomain: None, suffix: Some("kawasaki.jp") }
TldResult { domain: Some("city"), subdomain: Some("www"), suffix: Some("kawasaki.jp") }
```

---
---

# Behavior of other repos

---

Python's TldExtract ([repo](https://github.com/john-kurkowski/tldextract))
---

```sh
$ pip3 install tldextract
$ python3
```

```python
>>> import tldextract
>>> tldextract.extract('city.kawasaki.jp')
ExtractResult(subdomain='', domain='city', suffix='kawasaki.jp', is_private=False)
>>> tldextract.extract('www.city.kawasaki.jp')
ExtractResult(subdomain='www', domain='city', suffix='kawasaki.jp', is_private=False)
```

---

Go's TldExtract ([repo](https://github.com/joeguo/tldextract))
---

Code:

```go
package main

import (
        "fmt"
        "github.com/joeguo/tldextract"
)

func main() {
        fqdns := []string{"city.kawasaki.jp", "www.city.kawasaki.jp"}
        cache := "/tmp/tld.cache"
        extract, _ := tldextract.New(cache, false)

        for _, f := range fqdns {
                result := extract.Extract(f)
                fmt.Printf("%+v;%s\n", result, f)
        }
}
```

Output:

```sh
$ go run main.go
&{Flag:1 Sub: Root:city Tld:kawasaki.jp};city.kawasaki.jp
&{Flag:1 Sub:www Root:city Tld:kawasaki.jp};www.city.kawasaki.jp
```
